### PR TITLE
Fix line numbers in error messages

### DIFF
--- a/src/PolicyLexer.hs
+++ b/src/PolicyLexer.hs
@@ -28054,7 +28054,7 @@ data PState = PState {
 
 runP :: FilePath -> String -> P a -> Either String a
 runP fn input__ (P f)
-   = case f (PState {p_pos = SP fn 0 0,
+   = case f (PState {p_pos = SP fn 1 0,
                      p_inp = input__,
                      p_chr = '\n',
                      p_comment_depth = 0,

--- a/src/PolicyLexer.x.source
+++ b/src/PolicyLexer.x.source
@@ -189,7 +189,7 @@ data PState = PState {
 
 runP :: FilePath -> String -> P a -> Either String a
 runP fn input__ (P f)
-   = case f (PState {p_pos = SP fn 0 0,
+   = case f (PState {p_pos = SP fn 1 0,
                      p_inp = input__,
                      p_chr = '\n',
                      p_comment_depth = 0,


### PR DESCRIPTION
Make line numbers 1-indexed, rather than 0-indexed.