### PR TITLE
Allow policy-tool to build outside of a git repo

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,19 +29,19 @@
 module Main where
 
 import System.IO             (hPutStrLn, stderr, stdout)
-import System.IO.Error (IOError,ioeGetErrorString)
+import System.IO.Error       (IOError,ioeGetErrorString)
 import System.Environment    (getProgName,getArgs)
 import System.Exit           (exitWith,ExitCode(..),exitFailure,exitSuccess)
 import System.Console.GetOpt
-import System.Process (readProcess)
+import System.Process        (readProcess)
 import Control.Monad         (when)
-import Control.Exception (catch)
+import Control.Exception     (catch)
 import Data.Char             (isSpace)
 import Data.List             (nub, sort)
 import Data.Either           (lefts)
-import Data.Version (showVersion)
-import Language.Haskell.TH (stringE,runIO)
-import Paths_policy_tool (version)
+import Data.Version          (showVersion)
+import Language.Haskell.TH   (stringE,runIO)
+import Paths_policy_tool     (version)
 
 import AST
 import PolicyModules (getAllModules)


### PR DESCRIPTION
This catches the error that occurs when building the policy-tool outside of a git repo. Unfortunately, it still prints an error message (`fatal: not a git repository (or any of the parent directories): .git`), but it's no longer fatal.

`policy-tool --version` now prints one of
 * `Policy Tool v0.1.0.0 (git revision: failed)`
 * `Policy Tool v0.1.0.0 (git revision: 6a439e1)`