### PR TITLE
Additional exports to SrcPrinter module

### DIFF
--- a/src/SrcPrinter.hs
+++ b/src/SrcPrinter.hs
@@ -23,7 +23,10 @@
  - OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  - WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  -}
-module SrcPrinter (printPolicy,printRuleClause,printTagFieldBinOp) where
+module SrcPrinter 
+   (printPolicy, printRuleClause, printTagFieldBinOp,
+    printTag, printTagEx) 
+where
 
 import Data.List (intercalate)
 


### PR DESCRIPTION
https://github.com/draperlaboratory/hope-policy-interpreter makes use of some print functions that were not being exported, but are in this branch. 