### PR TITLE
"Depointer" Tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 dist/
 policy-tool.cabal
 *~
+/make_*.log
+/stack.yaml.lock

--- a/src/GenMetaSetH.hs
+++ b/src/GenMetaSetH.hs
@@ -85,13 +85,15 @@ tagSetFooter = unlines
 
 tagSetBody :: [Definition]
 tagSetBody = [cunit|
+  typedef typename intptr_t tag_t;
   typedef typename uintptr_t meta_t;
 
   typedef struct {
     typename META_SET_TAG_TYPE tags[ META_SET_WORDS ];
   } meta_set_t;
 
-  const meta_set_t* canonize(const meta_set_t* ts);
+  const tag_t canonize(const meta_set_t* ts);
+  const meta_set_t* get_ms(tag_t tag);
   typename bool ms_contains(const meta_set_t* ms, meta_t m);
   typename bool ms_eq(const meta_set_t* ms1, const meta_set_t* ms2);
   void ms_bit_add(meta_set_t* ms, meta_t m);

--- a/src/GenMetaSetH.hs
+++ b/src/GenMetaSetH.hs
@@ -91,6 +91,7 @@ tagSetBody = [cunit|
     typename META_SET_TAG_TYPE tags[ META_SET_WORDS ];
   } meta_set_t;
 
+  const meta_set_t* canonize(const meta_set_t* ts);
   typename bool ms_contains(const meta_set_t* ms, meta_t m);
   typename bool ms_eq(const meta_set_t* ms1, const meta_set_t* ms2);
   void ms_bit_add(meta_set_t* ms, meta_t m);

--- a/src/GenMetaSetH.hs
+++ b/src/GenMetaSetH.hs
@@ -92,7 +92,7 @@ tagSetBody = [cunit|
     typename META_SET_TAG_TYPE tags[ META_SET_WORDS ];
   } meta_set_t;
 
-  const tag_t canonize(const meta_set_t* ts);
+  tag_t canonize(const meta_set_t* ts);
   const meta_set_t* get_ms(tag_t tag);
   typename bool ms_contains(const meta_set_t* ms, meta_t m);
   typename bool ms_eq(const meta_set_t* ms1, const meta_set_t* ms2);

--- a/src/GenMetaSetH.hs
+++ b/src/GenMetaSetH.hs
@@ -48,6 +48,7 @@ tagSetHeader (TagInfo {tiMaxTag,tiArrayLength,
   ,"#include <stdint.h>"
   ,"#include <stdbool.h>"
   ,"#include <stddef.h>"
+  ,"#include \"tag_types.h\""
   ,""
   , "#ifdef __cplusplus"
   , "extern \"C\" {"
@@ -85,15 +86,14 @@ tagSetFooter = unlines
 
 tagSetBody :: [Definition]
 tagSetBody = [cunit|
-  typedef typename intptr_t tag_t;
   typedef typename uintptr_t meta_t;
 
   typedef struct {
     typename META_SET_TAG_TYPE tags[ META_SET_WORDS ];
   } meta_set_t;
 
-  tag_t canonize(const meta_set_t* ts);
-  const meta_set_t* get_ms(tag_t tag);
+  typename tag_t canonize(const meta_set_t* ts);
+  const meta_set_t* get_ms(typename tag_t tag);
   typename bool ms_contains(const meta_set_t* ms, meta_t m);
   typename bool ms_eq(const meta_set_t* ms1, const meta_set_t* ms2);
   void ms_bit_add(meta_set_t* ms, meta_t m);

--- a/src/GenRuleC.hs
+++ b/src/GenRuleC.hs
@@ -109,7 +109,7 @@ resultsType = [cty| typename results_t |]
 policyInputParams :: [Param]
 policyInputParams =
   [cparams|$ty:contextType* $id:contextArgName,
-           $ty:operandsType* $id:operandsArgName,
+           const $ty:operandsType* $id:operandsArgName,
            $ty:resultsType* $id:resultsArgName|]
 
 policyInputArgs :: [Exp]

--- a/src/GenRuleC.hs
+++ b/src/GenRuleC.hs
@@ -88,7 +88,8 @@ opsSetsArgName = operandsArgName ++ "->"
 resSetsArgName = resultsArgName ++ "->"
 contextArgName = "ctx"
 
-operandsArgName, resultsArgName, resultsPC, resultsRD, resultsCSR :: String
+metaSetsArgName, operandsArgName, resultsArgName, resultsPC, resultsRD, resultsCSR :: String
+metaSetsArgName = "ms_"
 operandsArgName = "ops"
 resultsArgName = "res"
 resultsPC = resSetsArgName ++ "pc"
@@ -96,12 +97,20 @@ resultsRD = resSetsArgName ++ "rd"
 resultsCSR = resSetsArgName ++ "csr"
 
 pcMetaSetName,ciMetaSetName,op1MetaSetName,op2MetaSetName,op3MetaSetName,memMetaSetName :: String
-pcMetaSetName = "get_ms(" ++ pcArgName ++ ")"
-ciMetaSetName = "get_ms(" ++ ciArgName ++ ")"
-op1MetaSetName = "get_ms(" ++ op1ArgName ++ ")"
-op2MetaSetName = "get_ms(" ++ op2ArgName ++ ")"
-op3MetaSetName = "get_ms(" ++ op3ArgName ++ ")"
-memMetaSetName = "get_ms(" ++ memArgName ++ ")"
+pcMetaSetName = metaSetsArgName ++ "pc"
+ciMetaSetName = metaSetsArgName ++ "ci"
+op1MetaSetName = metaSetsArgName ++ "op1"
+op2MetaSetName = metaSetsArgName ++ "op2"
+op3MetaSetName = metaSetsArgName ++ "op3"
+memMetaSetName = metaSetsArgName ++ "mem"
+
+pcGetMetaSetName,ciGetMetaSetName,op1GetMetaSetName,op2GetMetaSetName,op3GetMetaSetName,memGetMetaSetName :: String
+pcGetMetaSetName = "get_ms(" ++ pcArgName ++ ")"
+ciGetMetaSetName = "get_ms(" ++ ciArgName ++ ")"
+op1GetMetaSetName = "get_ms(" ++ op1ArgName ++ ")"
+op2GetMetaSetName = "get_ms(" ++ op2ArgName ++ ")"
+op3GetMetaSetName = "get_ms(" ++ op3ArgName ++ ")"
+memGetMetaSetName = "get_ms(" ++ memArgName ++ ")"
 
 -- For convenience, we define a few commonly used types and parameter/argument
 -- lists.
@@ -532,6 +541,13 @@ policyEval :: Bool -> Bool -> ModSymbols -> OpGroupMap
 policyEval debug _profile ms ogMap tagInfo (modN, pd@(PolicyDecl _ _ _ pEx)) =
   [cedecl|
        int $id:(singlePolicyEvalName pd) ($params:policyInputParams) {
+
+         typename meta_set_t* $id:pcMetaSetName = $id:pcGetMetaSetName;
+         typename meta_set_t* $id:ciMetaSetName = $id:ciGetMetaSetName;
+         typename meta_set_t* $id:op1MetaSetName = $id:op1GetMetaSetName;
+         typename meta_set_t* $id:op2MetaSetName = $id:op2GetMetaSetName;
+         typename meta_set_t* $id:op3MetaSetName = $id:op3GetMetaSetName;
+         typename meta_set_t* $id:memMetaSetName = $id:memGetMetaSetName;
 
          $stm:body
 

--- a/src/GenRuleC.hs
+++ b/src/GenRuleC.hs
@@ -860,24 +860,24 @@ translateBoundGroupEx ms mn mask ogMap varMap tagInfo (BoundGroupEx loc opr tse)
       -- preserved.  This may be wrong, though, for "global" policies like the
       -- loader.
       [citems|
-        { typename meta_set_t* res_tmp = malloc(sizeof(typename meta_set_t));
+        { typename meta_set_t res_tmp;
           if ($id:resHasResult) {
-            memcpy(res_tmp, $id:resPositionName, sizeof(typename meta_set_t));
+            memcpy(&res_tmp, $id:resPositionName, sizeof(typename meta_set_t));
           } else {
-            memset(res_tmp, 0, sizeof(typename meta_set_t));
+            memset(&res_tmp, 0, sizeof(typename meta_set_t));
           }
           typename meta_set_t $id:topVar;
           $items:evalItems;
           for(int i = 0; i < META_SET_BITFIELDS; i++) {
-              res_tmp->tags[i] |= ($id:topVar.tags[i] & $id:mask[i]);
+              res_tmp.tags[i] |= ($id:topVar.tags[i] & $id:mask[i]);
           }
           for(int i = META_SET_BITFIELDS; i < META_SET_WORDS; i++) {
             if($id:mask[i]) {
-              res_tmp->tags[i] =
+              res_tmp.tags[i] =
                 $id:topVar.tags[i];
             }
           }
-          $id:resPositionName = res_tmp;
+          $id:resPositionName = canonize(&res_tmp);
           $id:resHasResult = true;
         }
       |]

--- a/src/GenRuleC.hs
+++ b/src/GenRuleC.hs
@@ -95,13 +95,13 @@ resultsPC = resSetsArgName ++ "pc"
 resultsRD = resSetsArgName ++ "rd"
 resultsCSR = resSetsArgName ++ "csr"
 
-pcTagName,ciTagName,op1TagName,op2TagName,op3TagName,memTagName :: String
-pcTagName = "pc_tag"
-ciTagName = "ci_tag"
-op1TagName = "op1_tag"
-op2TagName = "op2_tag"
-op3TagName = "op3_tag"
-memTagName = "mem_tag"
+pcMetaSetName,ciMetaSetName,op1MetaSetName,op2MetaSetName,op3MetaSetName,memMetaSetName :: String
+pcMetaSetName = "get_ms(" ++ pcArgName ++ ")"
+ciMetaSetName = "get_ms(" ++ ciArgName ++ ")"
+op1MetaSetName = "get_ms(" ++ op1ArgName ++ ")"
+op2MetaSetName = "get_ms(" ++ op2ArgName ++ ")"
+op3MetaSetName = "get_ms(" ++ op3ArgName ++ ")"
+memMetaSetName = "get_ms(" ++ memArgName ++ ")"
 
 -- For convenience, we define a few commonly used types and parameter/argument
 -- lists.
@@ -221,18 +221,18 @@ patOperands ogMap og =
                        $ ognPats ogNames)
   where
     tagSpecPatName :: TagSpec -> String
-    tagSpecPatName RS1 = op1TagName
-    tagSpecPatName RS2 = op2TagName
-    tagSpecPatName RS3 = op3TagName
-    tagSpecPatName Mem = memTagName
-    tagSpecPatName Csr = op2TagName
+    tagSpecPatName RS1 = op1MetaSetName
+    tagSpecPatName RS2 = op2MetaSetName
+    tagSpecPatName RS3 = op3MetaSetName
+    tagSpecPatName Mem = memMetaSetName
+    tagSpecPatName Csr = op2MetaSetName
     tagSpecPatName ts =
       error $ "Error: illegal tag spec " ++ show ts
           ++ " in LHS of opgroup definition of " ++ tagString og ++ ".\n"
 
     standardOperands :: [(QSym, String)]
-    standardOperands = [(QVar ["env"],pcTagName),
-                        (QVar ["code"],ciTagName)]
+    standardOperands = [(QVar ["env"],pcMetaSetName),
+                        (QVar ["code"],ciMetaSetName)]
 
 expOperands :: OpGroupMap -> QSym -> [(QSym, String)]
 expOperands ogMap og =
@@ -532,12 +532,6 @@ policyEval :: Bool -> Bool -> ModSymbols -> OpGroupMap
 policyEval debug _profile ms ogMap tagInfo (modN, pd@(PolicyDecl _ _ _ pEx)) =
   [cedecl|
        int $id:(singlePolicyEvalName pd) ($params:policyInputParams) {
-         const typename meta_set_t* $id:pcTagName = $id:pcArgName != -1 ? get_ms($id:pcArgName) : NULL;
-         const typename meta_set_t* $id:ciTagName = $id:ciArgName != -1 ? get_ms($id:ciArgName) : NULL;
-         const typename meta_set_t* $id:op1TagName = $id:op1ArgName != -1 ? get_ms($id:op1ArgName) : NULL;
-         const typename meta_set_t* $id:op2TagName = $id:op2ArgName != -1 ? get_ms($id:op2ArgName) : NULL;
-         const typename meta_set_t* $id:op3TagName = $id:op3ArgName != -1 ? get_ms($id:op3ArgName) : NULL;
-         const typename meta_set_t* $id:memTagName = $id:memArgName != -1 ? get_ms($id:memArgName) : NULL;
 
          $stm:body
 
@@ -589,7 +583,7 @@ translatePolicy _ _ _ _ _ _
 translatePolicy dbg ms ogMap pd tagInfo modN
                 (PERule _ rc@(RuleClause _ ogrp rpat Nothing rres)) =
   [citems|
-       if(ms_contains($id:ciTagName,$id:(tagName (qualifiedOpGrpMacro)))) {
+       if(ms_contains($id:ciMetaSetName,$id:(tagName (qualifiedOpGrpMacro)))) {
          int $id:matchVar = $exp:patExp;
          if ($id:matchVar) {
            $stms:debugPrints
@@ -669,7 +663,7 @@ translatePatterns ms mn mask tagInfo ogmap pats =
     -- default binding for the env var, syntax sugar to allow it to be used in result
     -- without having been defined
     defaultEnv :: [(QSym,Exp)]
-    defaultEnv = [(QVar ["env"],[cexp|$id:pcTagName|])]
+    defaultEnv = [(QVar ["env"],[cexp|$id:pcMetaSetName|])]
     patternAcc :: (Exp,[(QSym,Exp)]) -> BoundGroupPat QSym
                -> (Exp,[(QSym,Exp)])
     patternAcc (e,ids) pat =

--- a/src/GenRuleC.hs
+++ b/src/GenRuleC.hs
@@ -860,17 +860,20 @@ translateBoundGroupEx ms mn mask ogMap varMap tagInfo (BoundGroupEx loc opr tse)
       -- preserved.  This may be wrong, though, for "global" policies like the
       -- loader.
       [citems|
-        { typename meta_set_t $id:topVar;
+        { typename meta_set_t* res_tmp = malloc(sizeof(typename meta_set_t));
+          memcpy(res_tmp, $id:resPositionName, sizeof(typename meta_set_t));
+          typename meta_set_t $id:topVar;
           $items:evalItems;
           for(int i = 0; i < META_SET_BITFIELDS; i++) {
-              ($id:resPositionName)->tags[i] |= ($id:topVar.tags[i] & $id:mask[i]);
+              res_tmp->tags[i] |= ($id:topVar.tags[i] & $id:mask[i]);
           }
           for(int i = META_SET_BITFIELDS; i < META_SET_WORDS; i++) {
             if($id:mask[i]) {
-              $id:resPositionName->tags[i] =
+              res_tmp->tags[i] =
                 $id:topVar.tags[i];
             }
           }
+          $id:resPositionName = res_tmp;
           $id:resHasResult = true;
         }
       |]
@@ -1041,6 +1044,7 @@ cHeader _debug _profile = [ "#include \"policy_meta.h\""
                          , "#include \"policy_meta_set.h\""
                          , "#include <stdbool.h>"
                          , "#include <stdint.h>"
+                         , "#include <stdlib.h>"
                          , "#include <stdio.h>"
                          , "#include <inttypes.h>"
                          , "#include <limits.h>"

--- a/src/GenRuleC.hs
+++ b/src/GenRuleC.hs
@@ -861,7 +861,11 @@ translateBoundGroupEx ms mn mask ogMap varMap tagInfo (BoundGroupEx loc opr tse)
       -- loader.
       [citems|
         { typename meta_set_t* res_tmp = malloc(sizeof(typename meta_set_t));
-          memcpy(res_tmp, $id:resPositionName, sizeof(typename meta_set_t));
+          if ($id:resHasResult) {
+            memcpy(res_tmp, $id:resPositionName, sizeof(typename meta_set_t));
+          } else {
+            memset(res_tmp, 0, sizeof(typename meta_set_t));
+          }
           typename meta_set_t $id:topVar;
           $items:evalItems;
           for(int i = 0; i < META_SET_BITFIELDS; i++) {
@@ -1044,7 +1048,6 @@ cHeader _debug _profile = [ "#include \"policy_meta.h\""
                          , "#include \"policy_meta_set.h\""
                          , "#include <stdbool.h>"
                          , "#include <stdint.h>"
-                         , "#include <stdlib.h>"
                          , "#include <stdio.h>"
                          , "#include <inttypes.h>"
                          , "#include <limits.h>"

--- a/src/GenUtilsC.hs
+++ b/src/GenUtilsC.hs
@@ -134,12 +134,8 @@ tagSetToString = [cedecl|
       buf[0] = '\0';
       return 3;
     }
-    if(ts == 0) {
-      strncpy(buf,"-0-",buf_len);
-      return 3;
-    }
-    if(ts == 0xFFFFFFFF) {
-      strncpy(buf,"<Invalid tag 0xFFFFFFFF>",buf_len);
+    if(ts == NULL) {
+      strncpy(buf,"<invalid>",buf_len);
       return 25;
     }
 


### PR DESCRIPTION
Convert tags from direct pointers to meta sets to indices into a meta set table, making them more flexible in where they are stored in memory and how they map to instruction/data words.

Requires C++ tagging tool conversion to be merged first.